### PR TITLE
Optionally show the volume level while muted

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -31,7 +31,7 @@ static void print_usage(const char* filename, int failure) {
     g_print("Usage: %s [-v] [-m] <volume>\n"
             " -h\t--help\t\thelp\n"
             " -v\t--verbose\tverbose\n"
-            " -m\t--mute\t\tmuted\n"
+            " -m\t--mute\t\tmuted [<volume>\t\tint 0-100]\n"
             " <volume>\t\tint 0-100\n", filename);
     if (failure)
         exit(EXIT_FAILURE);
@@ -52,8 +52,20 @@ int main(int argc, const char* argv[]) {
     if (help)
         print_usage(argv[0], FALSE);
 
-    gint volume = -1;
-    if (!muted) {
+    gint volume;
+    if (muted) {
+        if (argc > 2) {
+            print_usage(argv[0], TRUE);
+        } else if (argc == 2) {
+            if (sscanf(argv[1], "%d", &volume) != 1)
+                print_usage(argv[0], TRUE);
+
+            if (volume > 100 || volume < 0)
+                print_usage(argv[0], TRUE);
+        } else {
+            volume = 0;
+        }
+    } else {
         if (argc != 2)
             print_usage(argv[0], TRUE);
 
@@ -93,7 +105,7 @@ int main(int argc, const char* argv[]) {
     print_debug_ok(debug);
 
     print_debug("Sending volume...", debug);
-    uk_ac_cam_db538_VolumeNotification_notify(proxy, volume, &error);
+    uk_ac_cam_db538_VolumeNotification_notify(proxy, volume, muted, &error);
     if (error !=  NULL) {
         handle_error("Failed to send notification", error->message, FALSE);
         g_clear_error(&error);

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -60,6 +60,7 @@ typedef struct {
 GType volume_object_get_type(void);
 gboolean volume_object_notify(VolumeObject* obj,
                               gint value_in,
+                              gboolean muted,
                               GError** error);
 
 #define VOLUME_TYPE_OBJECT \
@@ -116,16 +117,16 @@ time_handler(VolumeObject *obj)
 
 gboolean volume_object_notify(VolumeObject* obj,
                               gint value,
+                              gboolean muted,
                               GError** error) {
     g_assert(obj != NULL);
 
-    if (value < 0) {
+    if (muted) {
         obj->muted = TRUE;
-        obj->volume = 0;
     } else {
         obj->muted = FALSE;
-        obj->volume = (value > 100) ? 100 : value;
     }
+    obj->volume = (value > 100) ? 100 : value;
 
     if (obj->notification == NULL) {
         print_debug("Creating new notification...", obj->debug);

--- a/src/specs.xml
+++ b/src/specs.xml
@@ -4,6 +4,7 @@
   <interface name="uk.ac.cam.db538.VolumeNotification">
     <method name="notify">
       <arg type="i" name="volume" direction="in" />
+      <arg type="b" name="muted" direction="in" />
     </method>
   </interface>
 </node>


### PR DESCRIPTION
This allows users to to see when current volume level while changing the volume in muted mode.

I like being able to mute the volume and then decrease without unmuting,
so very simplified I have bindings like these:

XF86AudioLowerVolume:

``` bash
    amixer set Master --$lvl
    if (muted) {
        voltune-show -m $lvl
    } else {
        voltune-show $lvl}
    )
```

XF86AudioRaiseVolume:

``` bash
    amixer set Master ++$lvl unmute
    voltune-show $lvl
```

XF86AudioMute:

``` bash
    voltume-show -m $lvl
```
