### PR TITLE
Allow one decimal place to daemon's --timeout argument 

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -132,7 +132,7 @@ gboolean volume_object_notify(VolumeObject* obj,
         print_debug("Creating new notification...", obj->debug);
         obj->notification = create_notification(obj->settings);
         gtk_widget_realize(GTK_WIDGET(obj->notification));
-        g_timeout_add(1000, (GSourceFunc) time_handler, (gpointer) obj);
+        g_timeout_add(100, (GSourceFunc) time_handler, (gpointer) obj);
         print_debug_ok(obj->debug);
     }
 
@@ -170,7 +170,7 @@ static void print_usage(const char* filename, int failure) {
             " -n\t\t--no-daemon\t\tdo not daemonize\n"
             "\n"
             "Configuration:\n"
-            " -t <int>\t--timeout <int>\t\tnotification timeout in seconds\n"
+            " -t <int>\t--timeout <float>\t\tnotification timeout in seconds with one optional decimal place\n"
             " -a <float>\t--alpha <float>\t\ttransparency level (0.0 - 1.0, default %.2f)\n"
             " -r <int>\t--corner-radius <int>\tradius of the round corners in pixels (default %d)\n"
             , filename, settings.alpha, settings.corner_radius);
@@ -182,6 +182,7 @@ static void print_usage(const char* filename, int failure) {
 
 int main(int argc, char* argv[]) {
     Settings settings = get_default_settings();
+    float timeout_in;
     int timeout = 3;
     
     void *options = gopt_sort(&argc, (const char**) argv, gopt_start(
@@ -197,8 +198,12 @@ int main(int argc, char* argv[]) {
     int no_daemon = gopt(options, 'n');
 
     if (gopt(options, 't')) {
-        if (sscanf(gopt_arg_i(options, 't', 0), "%d", &timeout) != 1)
+        if (sscanf(gopt_arg_i(options, 't', 0), "%f", &timeout_in) == 1
+                && timeout_in > 0.0f) {
+            timeout = (int) (timeout_in * 10);
+        } else {
             print_usage(argv[0], TRUE);
+        }
     }
     
     if (gopt(options, 'a')) {


### PR DESCRIPTION
Turns out that I think that the timeout of 1s is slightly too short, while 2s is far too long. I prefer a timeout of about 1.2s. 

This patch allow one optional decimal place to daemon's --timeout argument e.g.

``` bash
$ volnoti --timeout 1.5
```
